### PR TITLE
Make the postgres database persistent in the simple example

### DIFF
--- a/simple/docker-compose.yml
+++ b/simple/docker-compose.yml
@@ -1,4 +1,6 @@
-version: '2'
+volumes:
+  db_data:
+  
 services:
   buildbot:
     image: buildbot/buildbot-master:master
@@ -20,6 +22,8 @@ services:
     env_file:
       - db.env
     image: "postgres:9.4"
+    volumes: 
+      - db_data:/var/lib/postgresql/data
     expose:
       - 5432
 


### PR DESCRIPTION
By default the database container in the simple example is not persistent. When recreating the db container the data in the existing container is erased.

With this change the database content is stored in a docker volume so that the content is retained over rebuilds of the database container.